### PR TITLE
Remove promised lifestream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm test
+      - run: npm run test:esm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm install
       - run: npm run build
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "node test/index.test.js"
+    "test": "node test/index.test.js",
+    "test:esm": "node test/index.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharp-mozjpeg-image-processor",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Scaled and optimized JPEG image file generater powered by sharp and mozjpeg",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
@@ -42,7 +42,6 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "promised-lifestream": "^0.7.0",
     "sharp": "^0.33.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "0.7.1",
   "description": "Scaled and optimized JPEG image file generater powered by sharp and mozjpeg",
   "main": "lib/index.js",
+  "module": "lib/index.mjs",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
+      "require": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "require": "./lib/index.js"
+      "types": "./lib/index.d.ts"
     }
   },
   "files": [
@@ -16,6 +18,14 @@
   "scripts": {
     "build": "tsc",
     "test": "node test/index.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tilfin/sharp-mozjpeg-image-processor.git"
+  },
+  "homepage": "https://github.com/tilfin/sharp-mozjpeg-image-processor",
+  "bugs": {
+    "url": "https://github.com/tilfin/sharp-mozjpeg-image-processor/issues"
   },
   "keywords": [
     "image",

--- a/src/resizer.ts
+++ b/src/resizer.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { pipeline } from 'node:stream/promises'
+import { pipeline } from 'stream/promises'
 const sharp = require('sharp')
 
 export interface OutFileInfo {

--- a/src/resizer.ts
+++ b/src/resizer.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
+import { pipeline } from 'node:stream/promises'
 const sharp = require('sharp')
-const promisedLifestream = require('promised-lifestream')
 
 export interface OutFileInfo {
   format: 'jpeg'
@@ -20,11 +20,11 @@ export async function convertStreamToArrangedFile(srcFileStream: fs.ReadStream, 
                         .jpeg({ mozjpeg: true })
   const fileWriter = fs.createWriteStream(destFilePath, { encoding: undefined })
 
-  await promisedLifestream([
+  await pipeline(
     srcFileStream,
     largeResizer,
-    fileWriter,
-  ])
+    fileWriter
+  )
 
   return imgInfo!
 }

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { ImageProcessor } from '../lib/index.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const processor = new ImageProcessor()
+
+async function generateScaledImages(filePath) {
+  const srcStream = fs.createReadStream(filePath)
+  const imgInfos = [
+    {
+      kind: 'large',
+      width: 1200,
+      height: 1200,
+    },
+    {
+      kind: 'small',
+      width: 800,
+      height: 800,
+    },
+    {
+      kind: 'thumb',
+      width: 400,
+      height: 400,
+      crop: true,
+    }
+  ]
+  const quality = 70
+
+  const outImgInfos = await processor.execute(srcStream, imgInfos, quality)
+  for (let outImgInfo of outImgInfos) {
+    console.log(outImgInfo)
+  }
+}
+
+assert.doesNotReject(async () => {
+  const photoFilePath = path.join(__dirname, `test-photo.jpg`)
+  const photoFilePath1 = path.join(__dirname, `test1.temp.jpg`)
+  const photoFilePath2 = path.join(__dirname, `test2.temp.jpg`)
+  fs.copyFileSync(photoFilePath, photoFilePath1)
+  fs.copyFileSync(photoFilePath, photoFilePath2)
+
+  await Promise.all([
+    generateScaledImages(photoFilePath1),
+    generateScaledImages(photoFilePath2),
+  ])
+})


### PR DESCRIPTION
This pull request introduces updates to the CI workflow, modernizes the codebase by replacing deprecated dependencies, and adds support for ES modules. The most important changes include updating the Node.js versions and GitHub Actions in the CI configuration, replacing `promised-lifestream` with the native `pipeline` API, and enhancing the `package.json` file to support ES modules and provide additional metadata.

### CI Workflow Updates:
* Updated Node.js versions in the CI matrix to `20.x`, `22.x`, and `24.x`. Upgraded GitHub Actions (`actions/checkout` and `actions/setup-node`) to version 4. Added a new test step for ES module support (`npm run test:esm`). (`.github/workflows/ci.yml`)

### Code Modernization:
* Removed the `promised-lifestream` dependency and replaced it with the native `pipeline` API in `src/resizer.ts`. (`src/resizer.ts`) [[1]](diffhunk://#diff-fa20b36c132bc4b7035ae32b08b7bf5d146387134a2ba0f31af510b3fa3403efR2-L3) [[2]](diffhunk://#diff-fa20b36c132bc4b7035ae32b08b7bf5d146387134a2ba0f31af510b3fa3403efL23-R27)
* Removed the `promised-lifestream` package from `dependencies` in `package.json`. (`package.json`)

### ES Module Support and Metadata Enhancements:
* Added support for ES modules by introducing a `module` field in `package.json` and updating the `exports` field. Added a new script (`test:esm`) for testing ES modules. Included repository metadata (`repository`, `homepage`, and `bugs` fields) in `package.json`. (`package.json`)
* Added a new test file (`test/index.test.mjs`) to validate ES module functionality. (`test/index.test.mjs`)